### PR TITLE
Fix event delegation issue

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -28,6 +28,7 @@ function loadHomePage() {
 }
 
 function loadRecipeCard(event) {
+  if(event.target.closest('.recipe-card')) {
   loadHomePage()
   instruction.classList.remove('hidden')
   let selectedRecipe = recipeRepository.recipes.find(recipe => recipe.id === parseInt(event.target.closest('.recipe-card').id));
@@ -49,6 +50,7 @@ function loadRecipeCard(event) {
   `
   document.querySelector('.instruction-card-img').src = selectedRecipe.image;
   document.location.href = "#recipeDetailsContainer"
+  }
 }
 
 function loadSearchPage(array) {


### PR DESCRIPTION
## Is this a fix or a feature?
Fix
## What is the change?
built in if statement into event listener
## What does it fix?
When clicking on divs console errors appeared, an if statement is now built into the event listener to prevent loading outside of recipe card clicks
## Where should the reviewer start?
Review the loadRecipeCard function
## How should this be tested?
Click on areas outside of the recipe card to ensure the page does not load inappropriately 
## Relevant ScreenShots
